### PR TITLE
fix a compile error in GCC/Linux, etc.

### DIFF
--- a/src/server/room.cpp
+++ b/src/server/room.cpp
@@ -4571,11 +4571,11 @@ bool Room::askForDiscard(ServerPlayer *player, const QString &reason, int discar
 
     DummyCard *dummy_card = new DummyCard(to_discard);
     if (reason == "gamerule") {
-        CardMoveReason reason(CardMoveReason::S_REASON_RULEDISCARD, player->objectName(), QString(), dummy_card->getSkillName(), reason);
-        throwCard(dummy_card, reason, player);
+        CardMoveReason move_reason(CardMoveReason::S_REASON_RULEDISCARD, player->objectName(), QString(), dummy_card->getSkillName(), reason);
+        throwCard(dummy_card, move_reason, player);
     } else {
-        CardMoveReason reason(CardMoveReason::S_REASON_THROW, player->objectName(), QString(), dummy_card->getSkillName(), reason);
-        throwCard(dummy_card, reason, player);
+        CardMoveReason move_reason(CardMoveReason::S_REASON_THROW, player->objectName(), QString(), dummy_card->getSkillName(), reason);
+        throwCard(dummy_card, move_reason, player);
     }
 
     QVariant data;


### PR DESCRIPTION
In GCC, "reason" is known as a CardMoveReason variable instead of QString
